### PR TITLE
Ca portal search and filtering changes

### DIFF
--- a/apps/ca-portal/server/server/database/query_db.js
+++ b/apps/ca-portal/server/server/database/query_db.js
@@ -81,11 +81,20 @@ async function buildPositionFilterClause(filters, candidateUID) {
     };
   }
 
-  // Add "Course Level" filter (e.g., "100", "200").
-  if (filters.level) {
-    filterWhere.courseCode = {
-      contains: `-${filters.level.charAt(0)}`,
-    };
+  // Add "Course Level" filter (e.g., "100-level", "200-level").
+  if (filters.level && Array.isArray(filters.level) && filters.level.length > 0) {
+    const levelConditions = filters.level.map(levelString => {
+      // Extracts the first digit from strings like "100-level" -> "1"
+      const levelDigit = levelString.replace('-level', '').charAt(0);
+      return {
+        courseCode: {
+          contains: `-${levelDigit}`,
+        },
+      };
+    });
+
+    // Add the OR conditions to the main filter clause.
+    filterWhere.OR = levelConditions;
   }
 
   // Add "Location" filter.
@@ -611,11 +620,20 @@ function buildJobPositionForApplicationFilterClause(filters) {
     return where;
   }
 
-  // Filter by level
-  if (filters.level) {
-    where.courseCode = {
-      contains: `-${filters.level.charAt(0)}`,
-    };
+  // Add "Course Level" filter (e.g., "100-level", "200-level").
+  if (filters.level && Array.isArray(filters.level) && filters.level.length > 0) {
+    const levelConditions = filters.level.map(levelString => {
+      // Extracts the first digit from strings like "100-level" -> "1"
+      const levelDigit = levelString.replace('-level', '').charAt(0);
+      return {
+        courseCode: {
+          contains: `-${levelDigit}`,
+        },
+      };
+    });
+
+    // Add the OR conditions to the main filter clause.
+    where.OR = levelConditions;
   }
 
   // Filter by semester code

--- a/apps/ca-portal/ui/src/app/Applications/Candidate/[uid]/filter.config.js
+++ b/apps/ca-portal/ui/src/app/Applications/Candidate/[uid]/filter.config.js
@@ -10,10 +10,8 @@ export const generateApplicationsFilterConfig = (semesterOptions = []) => [
   {
     id: 'level',
     label: 'Course Level',
-    type: 'select',
-    placeholder: 'Any Level',
-    options: ["100", "200", "300", "400", "500", "600", "700"],
-    optionLabel: (level) => `${level}-level`,
+    type: 'checkbox',
+    options: ["100-level", "200-level", "300-level", "400-level", "500-level", "600-level", "700-level"]
   },
   {
     id: 'semester',

--- a/apps/ca-portal/ui/src/app/Applications/Candidate/[uid]/page.js
+++ b/apps/ca-portal/ui/src/app/Applications/Candidate/[uid]/page.js
@@ -1,13 +1,13 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { getCandidateApplicationsAsCandidate } from '@/services/db-apis';
 import { useAuth } from '@/contexts/AuthContext';
 import { gradeEnumToStringValue } from '@/constants/gradeConstants';
 
 import ApplicationCard from '@/components/applications/CandidateAndEmployee/ApplicationCard';
 import SearchBar from '@/components/common/searchAndFilter/SearchBar';
-import Filter from '@/components/common/searchAndFilter/Filter';
+import { Filter } from '@/components/common/searchAndFilter/Filter';
 import { generateApplicationsFilterConfig } from './filter.config';
 
 import Accordion from '@mui/material/Accordion';
@@ -19,6 +19,7 @@ import KeyboardArrowDownOutlinedIcon from '@mui/icons-material/KeyboardArrowDown
 
 export default function CandidateApplicationsPage() {
   const { currentUser, refreshUserProfile } = useAuth();
+  const filterRef = useRef();
 
   const [displayData, setDisplayData] = useState({});
   const [loading, setLoading] = useState(true);
@@ -28,7 +29,7 @@ export default function CandidateApplicationsPage() {
   const [searchTerm, setSearchTerm] = useState('');
   const [appliedFilters, setAppliedFilters] = useState({
     status: [],
-    level: '',
+    level: [],
     semester: '',
   });
 
@@ -131,7 +132,12 @@ export default function CandidateApplicationsPage() {
   // Called when the search form is submitted
   const handleSearch = (e) => {
     e.preventDefault();
-    updateApplicationsView(searchTerm, appliedFilters);
+    // Get the most up-to-date filters directly from the Filter component
+    const latestFilters = filterRef.current.getFilters();
+    // Update the parent's state so the UI is consistent
+    setAppliedFilters(latestFilters);
+    // Fetch data with the latest filters and search term
+    updateApplicationsView(searchTerm, latestFilters);
   };
 
   // --- Render Logic ---
@@ -171,6 +177,8 @@ export default function CandidateApplicationsPage() {
     );
   };
 
+  const totalApplications = Object.values(displayData).reduce((acc, apps) => acc + apps.length, 0);
+
   return (
     <main>
       <div className='flex flex-col items-center p-6 bg-white shadow-sm'>
@@ -187,6 +195,7 @@ export default function CandidateApplicationsPage() {
             />
             {filterConfig.length > 0 ? (
                 <Filter
+                  ref={filterRef}
                   onFilterChange={handleFilterChange}
                   filterConfig={filterConfig}
                 />
@@ -203,7 +212,16 @@ export default function CandidateApplicationsPage() {
       </Box>
 
       <div className='flex justify-center bg-gray-50 p-4 md:p-8 min-h-screen'>
-        {renderContent()}
+        <div className='w-full max-w-4xl'>
+          {!loading && !error && (
+            <div className="mb-4 text-sm text-gray-600">
+              <strong>
+                {totalApplications} {totalApplications === 1 ? 'application' : 'applications'} found
+              </strong>
+            </div>
+          )}
+          {renderContent()}
+        </div>
       </div>
     </main>
   );

--- a/apps/ca-portal/ui/src/app/Applications/Employee/[uid]/filter.config.js
+++ b/apps/ca-portal/ui/src/app/Applications/Employee/[uid]/filter.config.js
@@ -10,10 +10,8 @@ export const generateApplicationsFilterConfig = (semesterOptions = []) => [
   {
     id: 'level',
     label: 'Course Level',
-    type: 'select',
-    placeholder: 'Any Level',
-    options: ["100", "200", "300", "400", "500", "600", "700"],
-    optionLabel: (level) => `${level}-level`,
+    type: 'checkbox',
+    options: ["100-level", "200-level", "300-level", "400-level", "500-level", "600-level", "700-level"]
   },
   {
     id: 'semester',

--- a/apps/ca-portal/ui/src/app/Applications/Employee/[uid]/page.js
+++ b/apps/ca-portal/ui/src/app/Applications/Employee/[uid]/page.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { getCandidateApplicationsAsCandidate } from '@/services/db-apis';
 import { useAuth } from '@/contexts/AuthContext';
 import { gradeEnumToStringValue } from '@/constants/gradeConstants';
@@ -19,6 +19,7 @@ import KeyboardArrowDownOutlinedIcon from '@mui/icons-material/KeyboardArrowDown
 
 export default function CandidateApplicationsPage() {
   const { currentUser, refreshUserProfile } = useAuth();
+  const filterRef = useRef();
 
   const [displayData, setDisplayData] = useState({});
   const [loading, setLoading] = useState(true);
@@ -28,7 +29,7 @@ export default function CandidateApplicationsPage() {
   const [searchTerm, setSearchTerm] = useState('');
   const [appliedFilters, setAppliedFilters] = useState({
     status: [],
-    level: '',
+    level: [],
     semester: '',
   });
 
@@ -132,7 +133,12 @@ export default function CandidateApplicationsPage() {
   // Called when the search form is submitted
   const handleSearch = (e) => {
     e.preventDefault();
-    updateApplicationsView(searchTerm, appliedFilters);
+    // Get the most up-to-date filters directly from the Filter component
+    const latestFilters = filterRef.current.getFilters();
+    // Update the parent's state so the UI is consistent
+    setAppliedFilters(latestFilters);
+    // Fetch data with the latest filters and search term
+    updateApplicationsView(searchTerm, latestFilters);
   };
 
   // --- Render Logic ---
@@ -172,6 +178,8 @@ export default function CandidateApplicationsPage() {
     );
   };
 
+  const totalApplications = Object.values(displayData).reduce((acc, apps) => acc + apps.length, 0);
+
   return (
     <main>
       <div className='flex flex-col items-center p-6 bg-white shadow-sm'>
@@ -188,6 +196,7 @@ export default function CandidateApplicationsPage() {
             />
             {filterConfig.length > 0 ? (
                 <Filter
+                  ref={filterRef}
                   onFilterChange={handleFilterChange}
                   filterConfig={filterConfig}
                 />
@@ -204,7 +213,16 @@ export default function CandidateApplicationsPage() {
       </Box>
 
       <div className='flex justify-center bg-gray-50 p-4 md:p-8 min-h-screen'>
-        {renderContent()}
+        <div className='w-full max-w-4xl'>
+          {!loading && !error && (
+            <div className="mb-4 text-sm text-gray-600">
+              <strong>
+                {totalApplications} {totalApplications === 1 ? 'application' : 'applications'} found
+              </strong>
+            </div>
+          )}
+          {renderContent()}
+        </div>
       </div>
     </main>
   );

--- a/apps/ca-portal/ui/src/app/Applications/Employer/[uid]/filter.config.js
+++ b/apps/ca-portal/ui/src/app/Applications/Employer/[uid]/filter.config.js
@@ -10,10 +10,8 @@ export const generateApplicationsFilterConfig = (semesterOptions = []) => [
   {
     id: 'level',
     label: 'Course Level',
-    type: 'select',
-    placeholder: 'Any Level',
-    options: ["100", "200", "300", "400", "500", "600", "700"],
-    optionLabel: (level) => `${level}-level`,
+    type: 'checkbox',
+    options: ["100-level", "200-level", "300-level", "400-level", "500-level", "600-level", "700-level"]
   },
   {
     id: 'semester',

--- a/apps/ca-portal/ui/src/app/Applications/Employer/[uid]/page.js
+++ b/apps/ca-portal/ui/src/app/Applications/Employer/[uid]/page.js
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   getSemesterCodesForEmployer,
   getCandidateApplicationsAsEmployer,
@@ -10,7 +10,7 @@ import { gradeEnumToStringValue } from '@/constants/gradeConstants';
 
 import ApplicationCard from '@/components/applications/EmployerAndAdmin/ApplicationCard';
 import SearchBar from '@/components/common/searchAndFilter/SearchBar';
-import Filter from '@/components/common/searchAndFilter/Filter';
+import { Filter }from '@/components/common/searchAndFilter/Filter';
 import { generateApplicationsFilterConfig } from './filter.config';
 
 import Accordion from '@mui/material/Accordion';
@@ -23,6 +23,7 @@ import KeyboardArrowDownOutlinedIcon from '@mui/icons-material/KeyboardArrowDown
 
 export default function Applications() {
   const { currentUser } = useAuth();
+  const filterRef = useRef();
 
   // displayData is now an object where keys are semester codes and values are arrays of positions
   const [displayData, setDisplayData] = useState({});
@@ -33,7 +34,7 @@ export default function Applications() {
   const [filterConfig, setFilterConfig] = useState([]);
   const [appliedFilters, setAppliedFilters] = useState({
     status: [],
-    level: '',
+    level: [],
     semester: '',
     hasApplications: '',
   });
@@ -145,7 +146,12 @@ export default function Applications() {
 
   const handleSearch = (e) => {
     e.preventDefault();
-    updateApplicationsView(searchTerm, searchBy, appliedFilters);
+    // Get the most up-to-date filters directly from the Filter component
+    const latestFilters = filterRef.current.getFilters();
+    // Update the parent's state so the UI is consistent
+    setAppliedFilters(latestFilters);
+    // Fetch data with the latest filters and search term
+    updateApplicationsView(searchTerm, searchBy, latestFilters);
   };
 
   // --- Render Logic ---
@@ -214,12 +220,11 @@ export default function Applications() {
       return <div className='text-center p-8'>Loading applications...</div>;
     if (error)
       return <div className='text-red-500 text-center p-8'>Error: {error}</div>;
-    return (
-      <div id='section-container' className='w-full max-w-5xl p-2'>
-        {renderGroupedView()}
-      </div>
-    );
+    return renderGroupedView();
   };
+  
+  // Calculate the total number of applications
+  const totalApplications = Object.values(displayData).flat().reduce((acc, position) => acc + position.jobPositionApplicationHistory.length, 0);
 
   // Main body of application
   return (
@@ -257,6 +262,7 @@ export default function Applications() {
                   }
                 />
                 <Filter
+                  ref={filterRef}
                   onFilterChange={handleFilterChange}
                   filterConfig={filterConfig}
                 />
@@ -272,7 +278,16 @@ export default function Applications() {
               <div className='w-full mb-6 h-[88px] animate-pulse bg-gray-200 rounded-lg p-4'></div>
             )}
 
-            {renderContent()}
+            <div id='section-container' className='w-full max-w-5xl p-2'>
+              {!loading && !error && (
+                <div className="mb-4 text-sm text-gray-600">
+                  <strong>
+                    {totalApplications} {totalApplications === 1 ? 'application' : 'applications'} found
+                  </strong>
+                </div>
+              )}
+              {renderContent()}
+            </div>
           </div>
         ) : (
           <div>Please make sure you are logged in as an EMPLOYER.</div>

--- a/apps/ca-portal/ui/src/app/Positions/filter.config.js
+++ b/apps/ca-portal/ui/src/app/Positions/filter.config.js
@@ -10,10 +10,8 @@ export const positionFilterConfig = [
   {
     id: 'level',
     label: 'Course Level',
-    type: 'select',
-    placeholder: 'Any Level',
-    options: ["100", "200", "300", "400", "500", "600", "700"],
-    optionLabel: (level) => `${level}-level` // Custom label for the options
+    type: 'checkbox',
+    options: ["100-level", "200-level", "300-level", "400-level", "500-level", "600-level", "700-level"]
   },
   {
     id: 'location',

--- a/apps/ca-portal/ui/src/app/Positions/page.js
+++ b/apps/ca-portal/ui/src/app/Positions/page.js
@@ -1,24 +1,27 @@
+// src/app/Positions/page.js
 "use client";
 
-import React, { useEffect, useCallback, useState } from "react";
+import React, { useEffect, useCallback, useState, useRef } from "react";
 import { getOpenPositions } from "../../services/db-apis";
 import { useAuth } from "@/contexts/AuthContext";
 import { gradeEnumToStringValue } from "@/constants/gradeConstants";
 
 import PositionsCard from "@/components/positions/PositionsCard";
-import Filter from "@/components/common/searchAndFilter/Filter";
+import { Filter } from "@/components/common/searchAndFilter/Filter";
 import SearchBar from "@/components/common/searchAndFilter/SearchBar";
 import { positionFilterConfig } from "./filter.config";
 
 export default function Positions() {
   const { currentUser } = useAuth();
+  const filterRef = useRef();
+  
   const [openPositions, setOpenPositions] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
   const [searchTerm, setSearchTerm] = useState("");
   const [appliedFilters, setAppliedFilters] = useState({
     days: [],
-    level: "",
+    level: [],
     location: "",
     eligibility: "",
     applied: "",
@@ -65,7 +68,12 @@ export default function Positions() {
 
   const handleSearch = (e) => {
     e.preventDefault();
-    fetchData(searchTerm, appliedFilters);
+    // Get the most up-to-date filters directly from the Filter component
+    const latestFilters = filterRef.current.getFilters();
+    // Update the parent's state so the UI is consistent
+    setAppliedFilters(latestFilters);
+    // Fetch data with the latest filters and search term
+    fetchData(searchTerm, latestFilters);
   };
 
   const handleFilterChange = (filters) => {
@@ -126,7 +134,11 @@ export default function Positions() {
           <div id="positions-container" className="w-full max-w-4xl mx-auto">
             <form onSubmit={handleSearch} className="mb-8 flex items-center gap-x-2">
               <SearchBar value={searchTerm} onChange={handleSearchTermChange} placeholder="Search by course name or code..." />
-              <Filter onFilterChange={handleFilterChange} filterConfig={positionFilterConfig} />
+              <Filter 
+                ref={filterRef} 
+                onFilterChange={handleFilterChange} 
+                filterConfig={positionFilterConfig} 
+              />
               <button
                 type="submit"
                 className="h-10 rounded-md bg-rit-orange px-4 text-sm font-semibold text-white shadow-sm hover:bg-orange-700 focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-orange-600"
@@ -134,6 +146,13 @@ export default function Positions() {
                 Search
               </button>
             </form>
+            {!isLoading && !error && (
+              <div className="mb-4 text-sm text-gray-600">
+                <strong>
+                  {openPositions.length} {openPositions.length === 1 ? "result" : "results"}
+                </strong>
+              </div>
+            )}
             {renderContent()}
           </div>
         </div>

--- a/apps/ca-portal/ui/src/components/common/searchAndFilter/Filter.js
+++ b/apps/ca-portal/ui/src/components/common/searchAndFilter/Filter.js
@@ -1,5 +1,7 @@
+// src/components/common/searchAndFilter/Filter.js
 "use client";
-import React, { useState, useEffect, useRef } from "react";
+// 1. IMPORT forwardRef and useImperativeHandle
+import React, { useState, useEffect, useRef, useImperativeHandle, forwardRef } from "react";
 import { FilterIcon } from "../../../assets/icons";
 
 // Helper function to create the initial state from the configuration
@@ -11,13 +13,22 @@ const createInitialState = (config) => {
   return initialState;
 };
 
-export default function Filter({ onFilterChange, filterConfig }) {
+// 2. WRAP the component in forwardRef and accept 'ref' as the second argument
+export const Filter = forwardRef(function FilterComponent({ onFilterChange, filterConfig }, ref) {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedFilters, setSelectedFilters] = useState(
     createInitialState(filterConfig)
   );
 
   const wrapperRef = useRef(null);
+  
+  // 3. ADD useImperativeHandle to expose a function to the parent
+  useImperativeHandle(ref, () => ({
+    getFilters: () => {
+      // This function returns the component's current internal state
+      return selectedFilters;
+    }
+  }));
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -73,7 +84,6 @@ export default function Filter({ onFilterChange, filterConfig }) {
           <div className="p-4 max-h-96 overflow-y-auto">
             {filterConfig.map((filter) => (
               <div key={filter.id} className="mb-4">
-                {/* We only render the <h3> title if the filter is NOT a single-option checkbox. */}
                 {!(
                   filter.type === "checkbox" && filter.options.length === 1
                 ) && (
@@ -83,7 +93,6 @@ export default function Filter({ onFilterChange, filterConfig }) {
                 )}
 
                 {filter.type === "checkbox" && (
-                  // Use a simpler layout for single checkboxes
                   <div
                     className={
                       filter.options.length > 1
@@ -160,7 +169,6 @@ export default function Filter({ onFilterChange, filterConfig }) {
               </div>
             ))}
 
-            {/* Action Buttons */}
             <div className="pt-4 border-t border-gray-200 flex items-center justify-between">
               <button
                 onClick={handleClearFilters}
@@ -180,4 +188,4 @@ export default function Filter({ onFilterChange, filterConfig }) {
       )}
     </div>
   );
-}
+});


### PR DESCRIPTION
- Add total number of positions to the position search/filter (same thing for the applications page)
- Add 700-level filter to job positions
- Level selection filter should also be multiselect
- when a user clicks on any of the filter options and chooses to click on search instead of apply filters, allow the the inputted data to also be applied upon.